### PR TITLE
Button still depends on interactions@3.5.1 in yarn, even after removing resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "@react-aria/button": "3.3.3",
-    "@react-aria/interactions": "3.5.1",
     "@react-aria/menu": "3.6.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "@react-aria/interactions@3.5.1": "3.5.1"
-    }
-  },
-  "resolutions": {
-    "@react-aria/interactions@3.5.1": "3.5.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,16 +114,7 @@
     "@react-types/shared" "^3.22.0"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/interactions@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.5.1.tgz#4dc94af662f718ad985fad31440b11cef90109db"
-  integrity sha512-NLzYmHljXEqiUqr+PqszwFchGWUQc+kXWMI8N8vBra7HbPAej9so2iPU6hvn1k/3+b02kjt/2mqTrlN1T+HeGw==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/utils" "^3.8.2"
-    "@react-types/shared" "^3.8.0"
-
-"@react-aria/interactions@3.5.1@3.5.1", "@react-aria/interactions@^3.11.0", "@react-aria/interactions@^3.20.1", "@react-aria/interactions@^3.5.1":
+"@react-aria/interactions@^3.11.0", "@react-aria/interactions@^3.20.1", "@react-aria/interactions@^3.5.1":
   version "3.20.1"
   resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.20.1.tgz#397f6724935024e7d3f4f38e8fae07ee37da868d"
   integrity sha512-PLNBr87+SzRhe9PvvF9qvzYeP4ofTwfKSorwmO+hjr3qoczrSXf4LRQlb27wB6hF10C7ZE/XVbUI1lj4QQrZ/g==
@@ -302,7 +293,7 @@
   dependencies:
     "@react-types/shared" "^3.22.0"
 
-"@react-types/shared@^3.14.1", "@react-types/shared@^3.22.0", "@react-types/shared@^3.8.0":
+"@react-types/shared@^3.14.1", "@react-types/shared@^3.22.0":
   version "3.22.0"
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.22.0.tgz#70f85aad46cd225f7fcb29f1c2b5213163605074"
   integrity sha512-yVOekZWbtSmmiThGEIARbBpnmUIuePFlLyctjvCbgJgGhz8JnEJOipLQ/a4anaWfzAgzSceQP8j/K+VOOePleA==


### PR DESCRIPTION
Button still depends on interactions@3.5.1 in yarn, even after removing resolutions

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/jthemphill/pnpm-override/pull/7).
* __->__ #7
* #6
* #5
* #4
* #3
* #2
* #1